### PR TITLE
Added handling for empty responses from simply and added status_code to gem response

### DIFF
--- a/lib/m2y_simply/modules/base.rb
+++ b/lib/m2y_simply/modules/base.rb
@@ -19,7 +19,6 @@ module M2ySimply
       URI.parse M2ySimply.configuration.proxy
     end
 
-
     def self.post_encoded(url, body)
       headers = {}
       headers['Content-Type'] = "application/x-www-form-urlencoded"
@@ -31,7 +30,7 @@ module M2ySimply
       if headers.nil?
         headers = base_headers
       end
-      puts url
+      puts "Sending POST request to URL: #{url}"
       puts headers
       puts body
 
@@ -41,28 +40,32 @@ module M2ySimply
                     http_proxyuser: fixie.user,
                     http_proxypass: fixie.password)
     end
+
     def self.put(url, body, headers = nil)
       if headers.nil?
         headers = base_headers
       end
-      HTTParty.put(url, headers: headers, body: body,
-                   http_proxyaddr: fixie.host,
-                   http_proxyport: fixie.port,
-                   http_proxyuser: fixie.user,
-                   http_proxypass: fixie.password)
+      puts "Sending PUT request to URL: #{url}"
+      response = HTTParty.put(url, headers: headers, body: body,
+                              http_proxyaddr: fixie.host,
+                              http_proxyport: fixie.port,
+                              http_proxyuser: fixie.user,
+                              http_proxypass: fixie.password)
+      format_response(response)
     end
 
     def self.get(url, headers = nil)
       if headers.nil?
         headers = base_headers
       end
-      HTTParty.get(url, headers: headers,
-                   http_proxyaddr: fixie.host,
-                   http_proxyport: fixie.port,
-                   http_proxyuser: fixie.user,
-                   http_proxypass: fixie.password)
+      puts "Sending GET request to URL: #{url}"
+      response = HTTParty.get(url, headers: headers,
+                              http_proxyaddr: fixie.host,
+                              http_proxyport: fixie.port,
+                              http_proxyuser: fixie.user,
+                              http_proxypass: fixie.password)
+      format_response(response)
     end
-
 
     def self.base_headers
       headers = {}
@@ -71,5 +74,13 @@ module M2ySimply
       headers
     end
 
+    def self.format_response(original_response)
+      response = original_response.parsed_response
+      # Caso a parsed_response nao seja um hash, a response original veio com estrutura indeterminada
+      response = {} unless response.is_a?(Hash)
+      response[:status_code] = original_response.code
+      puts response
+      response
+    end
   end
 end

--- a/lib/m2y_simply/modules/proposals.rb
+++ b/lib/m2y_simply/modules/proposals.rb
@@ -8,16 +8,16 @@ module M2ySimply
         :CodigoWorkflow => M2ySimply.configuration.workflow,
         :DadosEntrada => body
       }
-      post(base_url + PROPOSALS_PATH, parsed_body.to_json).parsed_response
+      response = post(base_url + PROPOSALS_PATH, parsed_body.to_json)
+      format_response(response)
     end
 
     def self.send_document(proposal_id, file_name, base64)
-      body = {
-        :NomeArquivo => base64,
-        :BytesBase64 => file_name,
-        :IdentificadorObjeto => proposal_id
+      parsed_body = {
+        :NomeArquivo => file_name,
+        :BytesBase64 => base64
       }
-      put(base_url + PROPOSALS_PATH + proposal_id + DOCUMENTS_PATH, parsed_body.to_json).parsed_response
+      put(base_url + PROPOSALS_PATH + proposal_id + DOCUMENTS_PATH, parsed_body.to_json)
     end
 
     def self.approve_proposal(proposal_id)
@@ -25,8 +25,7 @@ module M2ySimply
     end
 
     def self.check_proposal(proposal_id)
-      get(base_url + PROPOSALS_PATH + proposal_id).parsed_response
+      get(base_url + PROPOSALS_PATH + proposal_id)
     end
-
   end
 end


### PR DESCRIPTION
Em casos de sucesso do send_document e approve_proposal, a Simply retorna apenas o código 200 sem nenhum body. Adicionei o tratamento para esse caso e também adicionei o campo status_code na response da gem, para que o projeto tenha acesso ao status da requisição.